### PR TITLE
Shipping cmd path removal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,6 @@ FORCE_DOWNLOAD="False" # Set to "True" to force re-download of the latest manife
 STEAM_USERNAME="xyz" # Your Steam username for DepotDownloader authentication.
 STEAM_PASSWORD="xyz" # Your Steam password for DepotDownloader authentication.
 STEAM_GAME_DOWNLOAD_PATH="C:/WRFrontiersDB/SteamDownload" # Path where the game will be downloaded by DepotDownloader. Ensure it exists. A prior version can exist here if not corrupted and it will be updated to latest version.
-SHIPPING_CMD_PATH="C:/Steam/steamapps/common/WRFrontiers/13_2017027/WRFrontiers/Binaries/Win64/WRFrontiers-Win64-Shipping.exe" # Path to the game's Shipping executable. Ensure it exists.
 DUMPER7_OUTPUT_DIR="C:/Dumper-7" # Path to Dumper-7's output folder. If your not sure where this path is for you, it is likely this default path. You can confirm by running src/mapper/get_mapper.py, letting it error, then looking for the directory. Ensure it exists. Content will be cleared before mapper is created so that the created mapper can be located properly.
 OUTPUT_MAPPER_FILE="C:/WRFrontiersDB/mapper.usmap" # Where the generated mapper file will be saved as. Ensure the parent dirs exists.
 OUTPUT_DATA_DIR="C:/WRFrontiersDB/ExportData" # Path to the where the output JSON will be saved. This should point to the "WRFrontiers\Content" folder that contains all json files of the game. Ensure it exists. When using BatchExport, it will wipe its contents before generating these files.

--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env2
 .venv
 env/
 venv/

--- a/src/mapper/get_mapper.py
+++ b/src/mapper/get_mapper.py
@@ -205,7 +205,14 @@ def main(params=None):
     if params is None:
         raise ValueError("Params must be provided")
 
-    game_process_name = os.path.basename(params.shipping_cmd_path)
+    # Construct shipping executable path from steam download path
+    shipping_cmd_path = os.path.join(params.steam_game_download_path, "13_2017027/WRFrontiers/Binaries/Win64/WRFrontiers-Win64-Shipping.exe")
+    
+    # Validate that the shipping executable exists
+    if not os.path.exists(shipping_cmd_path):
+        raise ValueError(f"Shipping executable not found at: {shipping_cmd_path}. Please ensure the game is downloaded to {params.steam_game_download_path}")
+    
+    game_process_name = os.path.basename(shipping_cmd_path)
 
     logger.info(f"Clearing Dumper-7 output directory: {params.dumper7_output_dir}")
     clear_dir(params.dumper7_output_dir)  # Clear Dumper-7 output directory before starting the game to ensure only new dumps are present
@@ -223,7 +230,7 @@ def main(params=None):
     dll_path = get_dll_path()
     
     # Launch the game process
-    game_process = launch_game_process(params.shipping_cmd_path)
+    game_process = launch_game_process(shipping_cmd_path)
     has_terminated = False
     mapping_file_path = None
     

--- a/src/run.py
+++ b/src/run.py
@@ -135,7 +135,7 @@ def run_mapper_creation(params):
         from mapper.get_mapper import main as mapper_main
         
         logger.info("Running DLL injection to create mapper file...")
-        logger.info(f"Game executable: {params.shipping_cmd_path}")
+        logger.info(f"Steam game download path: {params.steam_game_download_path}")
         logger.info(f"Dumper-7 output directory: {params.dumper7_output_dir}")
         logger.info(f"Output mapper file: {params.output_mapper_file}")
         

--- a/src/utils.py
+++ b/src/utils.py
@@ -31,7 +31,6 @@ class Params:
         self.steam_game_download_path = steam_game_download_path if steam_game_download_path is not None else os.getenv('STEAM_GAME_DOWNLOAD_PATH')
         
         # Mapping
-        self.shipping_cmd_path = shipping_cmd_path if shipping_cmd_path is not None else os.getenv('SHIPPING_CMD_PATH')
         self.dumper7_output_dir = dumper7_output_dir if dumper7_output_dir is not None else os.getenv('DUMPER7_OUTPUT_DIR')
 
         # BatchExport
@@ -82,11 +81,6 @@ class Params:
         
 
         # Mapping
-        if not self.shipping_cmd_path:
-            raise ValueError("SHIPPING_CMD_PATH environment variable is not set.")
-        if not os.path.exists(self.shipping_cmd_path):
-            raise ValueError(f"SHIPPING_CMD_PATH '{self.shipping_cmd_path}' does not exist.")
-        
         if not self.dumper7_output_dir:
             raise ValueError("DUMPER7_OUTPUT_DIR environment variable is not set.")
         if not os.path.exists(self.dumper7_output_dir):
@@ -119,7 +113,6 @@ class Params:
             #f"STEAM_PASSWORD: {self.steam_password}\n"
             f"STEAM_GAME_DOWNLOAD_PATH: {self.steam_game_download_path}\n"
             
-            f"SHIPPING_CMD_PATH: {self.shipping_cmd_path}\n"
             f"DUMPER7_OUTPUT_DIR: {self.dumper7_output_dir}\n"
 
             f"OUTPUT_MAPPER_FILE: {self.output_mapper_file}\n"


### PR DESCRIPTION
SHIPPING_CMD_PATH removed, as it can be determined by joining a static path to the STEAM_GAME_DOWNLOAD_PATH