### PR TITLE
Bugfixes for batchexport download, blank manifestid, password logging, runtime error incorrectly caught; misc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,7 +45,7 @@ SHOULD_GET_MAPPER="False"
 
 # Re-generate the mapping file even if it already exists.
 # Required when SHOULD_GET_MAPPER is True
-FORCE_GET_MAPPER="True"
+FORCE_GET_MAPPER="False"
 
 # Path to the where Dumper7 outputs its generated SDK.
 # Required when SHOULD_GET_MAPPER is True
@@ -62,7 +62,7 @@ SHOULD_BATCH_EXPORT="False"
 
 # Re-run the BatchExport even if output directory is not empty.
 # Required when SHOULD_BATCH_EXPORT is True
-FORCE_EXPORT="True"
+FORCE_EXPORT="False"
 
 # Path to save the exported assets to.
 # Required when SHOULD_BATCH_EXPORT is True

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Copy `.env.example` to `.env` and configure the following parameters, unless the
   - Command line: `--should-get-mapper`
 
 * **FORCE_GET_MAPPER** - Re-generate the mapping file even if it already exists.
-  - Default: `"true"`
+  - Default: `"false"`
   - Command line: `--force-get-mapper`
   - Depends on: `SHOULD_GET_MAPPER`
 
@@ -158,7 +158,7 @@ Copy `.env.example` to `.env` and configure the following parameters, unless the
   - Command line: `--should-batch-export`
 
 * **FORCE_EXPORT** - Re-run the BatchExport even if output directory is not empty.
-  - Default: `"true"`
+  - Default: `"false"`
   - Command line: `--force-export`
   - Depends on: `SHOULD_BATCH_EXPORT`
 

--- a/src/dependency_manager.py
+++ b/src/dependency_manager.py
@@ -431,7 +431,7 @@ def install_batch_export(output_path: Optional[Union[str, Path]] = None, force: 
     try:
         return dm.download_github_release_latest(
             repo_owner="Surxe",
-            repo_name="batch_export", 
+            repo_name="CUE4P-BatchExport", 
             asset_pattern=["BatchExport-windows-x64.zip", "README.md"],
             output_path=output_path,
             executable_name="BatchExport.exe",

--- a/src/options.py
+++ b/src/options.py
@@ -123,11 +123,11 @@ class Options:
             # 1. Check args first
             if attr_name in args_dict and args_dict[attr_name] is not None:
                 value = args_dict[attr_name]
-                logger.debug(f"Argument {attr_name} found in args with value: {value}")
+                logger.debug(f"Argument {attr_name} found in args with value: {value if not details.get('sensitive', False) else '***HIDDEN***'}")
             # 2. Check environment variable
             elif details["env"] in os.environ:
                 env_value = os.environ[details["env"]]
-                logger.debug(f"Environment variable {details['env']} found with value: {env_value}")
+                logger.debug(f"Environment variable {details['env']} found with value: {env_value if not details.get('sensitive', False) else '***HIDDEN***'}")
                 # Convert environment string to proper type
                 if details["type"] == bool:
                     value = is_truthy(env_value)
@@ -192,7 +192,7 @@ class Options:
                         f"{option_name} is required when any of the following are true: "
                         f"{', '.join(depends_on_list)}. Currently active: {', '.join(active_dependencies)}"
                     )
-                logger.debug(f"Dependent option {option_name} is set to {value if not details.get('sensitive', False) else '***HIDDEN***'} as required.")
+                logger.debug(f"Dependent option {option_name} is set to {value if not details.get('sensitive', False) else '***HIDDEN***'}")
         
     def log(self):
         """

--- a/src/options.py
+++ b/src/options.py
@@ -82,7 +82,7 @@ class Options:
             # Convert schema key (UPPER_CASE) to attribute name (lower_case)
             attr_name = key.lower()
             setattr(self, attr_name, value)
-            logger.debug(f"Set attribute {attr_name} to value: {value}")
+            logger.debug(f"Set attribute {attr_name} to value: {value if not details.get('sensitive', False) else '***HIDDEN***'}")
 
         self.validate()
 
@@ -192,7 +192,7 @@ class Options:
                         f"{option_name} is required when any of the following are true: "
                         f"{', '.join(depends_on_list)}. Currently active: {', '.join(active_dependencies)}"
                     )
-                logger.debug(f"Dependent option {option_name} is set to {value}")
+                logger.debug(f"Dependent option {option_name} is set to {value if not details.get('sensitive', False) else '***HIDDEN***'} as required.")
         
     def log(self):
         """

--- a/src/options_schema.py
+++ b/src/options_schema.py
@@ -110,7 +110,7 @@ OPTIONS_SCHEMA = {
         "env": "FORCE_GET_MAPPER",
         "arg": "--force-get-mapper",
         "type": bool,
-        "default": True,
+        "default": False,
         "help": "Re-generate the mapping file even if it already exists.",
         "section": "Mapping",
         "depends_on": ["SHOULD_GET_MAPPER"]
@@ -146,7 +146,7 @@ OPTIONS_SCHEMA = {
         "env": "FORCE_EXPORT",
         "arg": "--force-export",
         "type": bool,
-        "default": True,
+        "default": False,
         "help": "Re-run the BatchExport even if output directory is not empty.",
         "section": "Batch Export",
         "depends_on": ["SHOULD_BATCH_EXPORT"]

--- a/src/run.py
+++ b/src/run.py
@@ -55,6 +55,10 @@ def run_dependency_manager(options: Options) -> bool:
         elapsed_time = end_time - start_time
         logger.debug(f"Dependency manager timer ended at {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(end_time))}")
         logger.debug(f"Dependency manager execution time: {elapsed_time:.2f} seconds ({elapsed_time/60:.2f} minutes)")
+
+        if not result:
+            logger.error("Dependency manager reported failure.")
+            return False
         
         logger.success("Dependency manager completed successfully!")
         return True
@@ -99,13 +103,17 @@ def run_steam_download_update(options: Options) -> bool:
             steam_password=options.steam_password,
             force=options.force_steam_download,
         )
-        result = downloader.run(manifest_id=options.manifest_id)
-        
+        manifest_id = None if options.manifest_id == "" else options.manifest_id
+        result = downloader.run(manifest_id=manifest_id)
+
         end_time = time.time()
         elapsed_time = end_time - start_time
         logger.debug(f"Steam download/update timer ended at {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(end_time))}")
         logger.debug(f"Steam download/update execution time: {elapsed_time:.2f} seconds ({elapsed_time/60:.2f} minutes)")
         
+        if not result:
+            logger.error("Steam download/update reported failure.")
+            return False
         logger.success("Steam download/update completed successfully!")
         return True
         

--- a/src/steam/run_depot_downloader.py
+++ b/src/steam/run_depot_downloader.py
@@ -27,7 +27,7 @@ class DepotDownloader:
         self.manifest_path = os.path.join(self.wrf_dir, 'manifest.txt')
         self.force = force
 
-    def run(self, manifest_id: Optional[str]) -> None:
+    def run(self, manifest_id: Optional[str | None]) -> None:
         # no input manifest id downloads the latest version
         if manifest_id is None:
             manifest_id = self._get_latest_manifest_id()
@@ -37,10 +37,12 @@ class DepotDownloader:
         downloaded_manifest_id = self._read_downloaded_manifest_id()
         if downloaded_manifest_id == manifest_id and not self.force:
             logger.info(f'Already downloaded manifest {manifest_id}')
-            return
+            return True
 
         self._download(manifest_id)
         self._write_downloaded_manifest_id(manifest_id)
+
+        return True
 
     def _download(self, manifest_id: str) -> None:
         logger.debug(f'Downloading game with manifest id {manifest_id}')
@@ -57,7 +59,7 @@ class DepotDownloader:
         ]
         run_process(subprocess_options, name='download-game-files')
 
-        # todo, verify files are downloaded
+        #TODO, verify files are downloaded
 
     def _read_downloaded_manifest_id(self) -> Optional[str]:
         if not os.path.exists(self.manifest_path):

--- a/tests/test_options/test_init_options.py
+++ b/tests/test_options/test_init_options.py
@@ -234,7 +234,7 @@ class TestInitOptions(unittest.TestCase):
         # None values should trigger fallback to environment/defaults
         self.assertEqual(options.log_level, "DEBUG")  # Default
         self.assertEqual(options.steam_username, "test")
-        self.assertTrue(options.force_export)  # Default True
+        self.assertFalse(options.force_export)  # Default is False
 
     @patch.dict(os.environ, {}, clear=True)  # Clear environment to test pure defaults
     def test_init_options_partial_arguments(self):
@@ -259,7 +259,7 @@ class TestInitOptions(unittest.TestCase):
         
         # Unprovided arguments should use defaults
         self.assertFalse(options.force_download_dependencies)  # Default False
-        self.assertTrue(options.force_get_mapper)  # Default True
+        self.assertFalse(options.force_get_mapper)  # Default False
 
 
 # Mock the file system dependencies for environment tests


### PR DESCRIPTION
* Fixed wrong repo name for batch export dependency download
* Password no longer logged
* Dependency manager and steam download errors now end runtime as expected
* Fixed blank manifest id's not being interpreted as 'get latest' correctly
* All --force-x params defaulted to false