### PR TITLE
Blank manifest id cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,9 @@ SHOULD_DOWNLOAD_STEAM_GAME="False"
 # Required when SHOULD_DOWNLOAD_STEAM_GAME is True
 FORCE_STEAM_DOWNLOAD="False"
 
-# Steam manifest ID to download. If blank, the latest manifest ID will be used.
+# Steam manifest ID to download. If 'latest', the latest manifest ID will be used.
 # Required when SHOULD_DOWNLOAD_STEAM_GAME is True
-MANIFEST_ID=""
+MANIFEST_ID="latest"
 
 # Steam username for authentication.
 # Required when SHOULD_DOWNLOAD_STEAM_GAME is True
@@ -52,7 +52,7 @@ FORCE_GET_MAPPER="False"
 DUMPER7_OUTPUT_DIR=""
 
 # Path to save the generated mapping file (.usmap) at. Should end in .usmap
-# Required when SHOULD_GET_MAPPER is True
+# Required when SHOULD_GET_MAPPER or SHOULD_BATCH_EXPORT is True
 OUTPUT_MAPPER_FILE=""
 
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A comprehensive data extraction pipeline for War Robots Frontiers that downloads game files, creates a mapping file, and exports game assets to JSON format.
 
+
 ## Overview
 
 WRFrontiers-Exporter orchestrates a complete 4-step process to extract and convert War Robots Frontiers game data:
@@ -10,6 +11,7 @@ WRFrontiers-Exporter orchestrates a complete 4-step process to extract and conve
 2. **Steam Download/Update** - Downloads/updates game files via DepotDownloader  
 3. **DLL Injection for Mapper** - Creates mapper file via game injection
 4. **BatchExport** - Converts game assets to JSON format
+
 
 ## Process Details
 
@@ -23,18 +25,21 @@ WRFrontiers-Exporter orchestrates a complete 4-step process to extract and conve
 - Download is saved at `STEAM_GAME_DOWNLOAD_DIR`
 - Supports downloading specific manifest versions or latest version
 - Uses Steam credentials for authentication
+- Manifest id (if downloaded latest via `MANIFEST_ID`=`latest`) is saved to `STEAM_GAME_DOWNLOAD_DIR`/manifest.txt
 
 ### 3. DLL Injection for Mapper File
 - Runs WRF's `Shipping.exe` from the downloaded game files to launch the game without being logged in to Steam
 - Injects `src\mapper\Dumper-7.dll` to it to make an SDK
 - Extracts the mapper file from the SDK generated in `DUMPER7_OUTPUT_DIR` and copies it to `OUTPUT_MAPPER_FILE`
 - May require administrator privileges for DLL injection
+- Game cannot be currently open through another source, even through a different steam account
 
 ### 4. BatchExport
 - Uses the mapper file and steam download
 - Exports all `.pak`, `.utoc`, and `.locres` source files to `.json`
 - Saves them in `OUTPUT_DATA_DIR`
 - Converts game assets to human-readable JSON format
+
 
 ## Installation
 
@@ -59,6 +64,7 @@ cp .env.example .env
 ```bash
 python src/run.py --help
 ```
+
 
 ## Options
 
@@ -146,9 +152,9 @@ Copy `.env.example` to `.env` and configure the following parameters, unless the
   - If unsure where this is, it is likely `C:/Dumper-7`. Confirm by running the mapper, letting it fail, and checking for the dir.
 
 * **OUTPUT_MAPPER_FILE** - Path to save the generated mapping file (.usmap) at. Should end in .usmap
-  - Default: None - required when SHOULD_GET_MAPPER is True
+  - Default: None - required when SHOULD_GET_MAPPER or SHOULD_BATCH_EXPORT is True
   - Command line: `--output-mapper-file`
-  - Depends on: `SHOULD_GET_MAPPER`
+  - Depends on: `SHOULD_GET_MAPPER`, `SHOULD_BATCH_EXPORT`
 
 
 #### Batch Export
@@ -176,10 +182,8 @@ Copy `.env.example` to `.env` and configure the following parameters, unless the
   * Option
   * Default
 * If all options prefixed with `SHOULD_` are defaulted to `False`, they are instead all defaulted to `True` for ease of use
-* Options are only required if their section's `SHOULD_` option is `True`
+* Options are only required if their section's root `SHOULD_` option is `True`
 
-### Batch Export Options
-For customizing Batch Export's options, namely paths to export, see `src\batch_export\BatchExport\README.md` after downloading dependencies. A custom needed exports and appsettings file can be created in the BatchExport installation directory as it is gitignored.
 
 ## Requirements
 
@@ -188,30 +192,6 @@ For customizing Batch Export's options, namely paths to export, see `src\batch_e
 - Steam account credentials
 - Windows OS (for game execution and DLL injection)
 
-## Directory Structure
-
-```
-WRFrontiers-Exporter/
-├── src/
-│   ├── run.py                       # Main orchestration script
-│   ├── utils.py                     # Shared utilities and option management
-│   ├── dependency_manager.py        # Dependency download/update management
-│   ├── steam/
-│   │   └── run_depot_downloader.py  # Steam game download
-│   │   └── DepotDownloader/         # DepotDownloader installation (after downloaded)
-│   ├── mapper/   
-│   │   ├── get_mapper.py            # DLL injection and mapper creation
-│   │   ├── simple_injector.py       # DLL injection utilities
-│   │   └── Dumper-7.dll             # UE4 SDK generation DLL
-│   └── batch_export/   
-│       └── run_batch_export.py      # Asset export to JSON
-│       └── BatchExport/             # BatchExport installation (after downloaded)
-│           └── README.md/           # BatchExport documentation
-├── logs/                            # Log files
-├── .env.example                     # Environment configuration template
-├── requirements.txt                 # Python dependencies
-└── README.md                        # This file
-```
 
 ## Troubleshooting
 
@@ -237,23 +217,12 @@ WRFrontiers-Exporter/
    - Check that output directories are writable
    - Verify antivirus isn't blocking file operations
 
-### Debug Mode
-
-Run with debug logging for detailed troubleshooting:
-```bash
-python src/run.py --log-level DEBUG
-```
 
 ## Contributing
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
-3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
-4. Push to the branch (`git push origin feature/AmazingFeature`)
-5. Open a Pull Request
+* After making changes to `options_schema.py`, rerun `build/docs.py` to rebuild the `.env.example` and `README.md`
+* Follow standards set by `STANDARDS.md`
 
-* After making changes to `src/options_schema.py`, rerun `build_scripts/build_docs.py` to rebuild the `.env.example` and `README.md`
-* Follow standards set by `STANDARDS.md` (barebones atm)
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Copy `.env.example` to `.env` and configure the following parameters, unless the
   - Command line: `--force-steam-download`
   - Depends on: `SHOULD_DOWNLOAD_STEAM_GAME`
 
-* **MANIFEST_ID** - Steam manifest ID to download. If blank, the latest manifest ID will be used.
-  - Default: `""` (empty)
+* **MANIFEST_ID** - Steam manifest ID to download. If 'latest', the latest manifest ID will be used.
+  - Default: `"latest"`
   - Command line: `--manifest-id`
   - Depends on: `SHOULD_DOWNLOAD_STEAM_GAME`
   - See [SteamDB](https://steamdb.info/app/1491000/depot/1491005/manifests/) for available values

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -4,7 +4,7 @@
 
 ### Case
 - **snake_case** - Used for variables and functions
-- **PascalCase** - Used for class names (e.g., `DependencyManager`, `ArgumentWriter`, `Options`)
+- **PascalCase** - Used for class names (e.g., `DependencyManager`, `Options`)
 - ***CREAMING_SNAKE_CASE** - Used for schema keys and environment variables (e.g., `LOG_LEVEL`, `STEAM_USERNAME`)
 
 ### Path Variable Naming
@@ -15,7 +15,7 @@
 * **Path** - Generic - Ideally is changed to either dir, cmd, or file
 
 ### Function/Method Naming
-* **Private methods** - Methods that use (not just have) `self` arg. Prefixed with `_` (e.g., `_process_schema`, `_download_file`, `_validate_zip_file`)
+* **Private methods** - Methods that use (not just have) `self` arg. Prefixed with `_` (e.g., `_download_file`, `_validate_zip_file`)
 
 ### File Extensions & Types
 * **Configuration files** - `.json` (e.g., `appsettings.template.json`)
@@ -42,8 +42,8 @@
 * **Parameter / Environment Variable** - `.env` provided variable, i.e. `LOG_LEVEL`
 * **Default** - Default value for a given option
 * **Option** - Argument, parameter, or default (in descending order of priority)
-* **Root Option** - An option that has sub-options via `section_options` (e.g., `SHOULD_DOWNLOAD_STEAM_GAME`)
-* **Section Option** - A sub-option of the section's root option (e.g., `STEAM_USERNAME` under `SHOULD_DOWNLOAD_STEAM_GAME`)
+* **Root Option** - An option that has other options that depend on it via `depends_on` (e.g., `SHOULD_DOWNLOAD_STEAM_GAME`)
+* **Dependent Option** - A dependent-option of the section's root option (e.g., `STEAM_USERNAME` under `SHOULD_DOWNLOAD_STEAM_GAME`)
 
 ### Process Management
 * **Process** - Running executable/application instance

--- a/options_schema.py
+++ b/options_schema.py
@@ -122,7 +122,7 @@ OPTIONS_SCHEMA = {
         "default": None,
         "help": "Path to save the generated mapping file (.usmap) at. Should end in .usmap",
         "section": "Mapping",
-        "depends_on": ["SHOULD_GET_MAPPER"]
+        "depends_on": ["SHOULD_GET_MAPPER", "SHOULD_BATCH_EXPORT"]
     },
     "SHOULD_BATCH_EXPORT": {
         "env": "SHOULD_BATCH_EXPORT",

--- a/options_schema.py
+++ b/options_schema.py
@@ -64,8 +64,8 @@ OPTIONS_SCHEMA = {
         "env": "MANIFEST_ID",
         "arg": "--manifest-id",
         "type": str,
-        "default": "",
-        "help": "Steam manifest ID to download. If blank, the latest manifest ID will be used.",
+        "default": "latest",
+        "help": "Steam manifest ID to download. If 'latest', the latest manifest ID will be used.",
         "links": {"SteamDB": "https://steamdb.info/app/1491000/depot/1491005/manifests/"},
         "section": "Steam Download",
         "depends_on": ["SHOULD_DOWNLOAD_STEAM_GAME"]

--- a/options_schema.py
+++ b/options_schema.py
@@ -2,16 +2,6 @@ from typing import Literal
 from pathlib import Path
 
 """
-# Schema
-* **env** - Environment variable name (UPPER_CASE)
-* **arg** - Command line argument (kebab-case with --)
-* **type** - Python type (bool, str, Path, Literal)
-* **default** - Default value. None means its required if it's root option is True
-* **help** - Description text
-* **section** - Logical grouping name
-* **section_options** - Nested sub-options
-* **sensitive** - Boolean flag for password masking
-
 # Patterns
 * **should_** - Main action flags (e.g., `should_download_steam_game`)
 * **force_** - Override/refresh flags (e.g., `force_download_dependencies`)

--- a/src/batch_export/run_batch_export.py
+++ b/src/batch_export/run_batch_export.py
@@ -10,17 +10,6 @@ from optionsconfig import init_options, Options
 from utils import run_process
 from loguru import logger
 
-"""
-Usage:
-    python batchexport.py <mapping_file_path>
-
-Example:
-    python batchexport.py /path/to/mapping/file.usmap
-
-Alternatively, you can import and use the BatchExporter class directly:
-"""
-
-
 class BatchExporter:
     """
     A class to handle batch exporting of game assets using the CUE4P BatchExport tool.
@@ -68,13 +57,13 @@ class BatchExporter:
         if not self.executable_path.exists():
             raise FileNotFoundError(
                 f"BatchExport.exe not found at {self.executable_path}. "
-                "Please run install_batch_export.sh first to download it."
+                "Please use should_download_dependencies first to download it."
             )
         
         if not os.path.exists(self.options.steam_game_download_dir):
             raise FileNotFoundError(
                 f"Steam game download path not found: {self.options.steam_game_download_dir}. "
-                "Please ensure STEAM_GAME_DOWNLOAD_DIR is set correctly in your environment."
+                "Please ensure steam_game_download_dir is set correctly in your environment."
             )
         
         # Create output data directory if it doesn't exist

--- a/src/mapper/get_mapper.py
+++ b/src/mapper/get_mapper.py
@@ -252,7 +252,7 @@ def main(options: Optional[Options] = None) -> str:
         terminate_game_process(game_process, game_process_name)
         has_terminated = True
 
-        logger.warning("DLL injection says it failed, but it could be incorrect. Checking if the mapping file was created...")
+        logger.info("DLL injection says it failed, but it could be incorrect. Checking if the mapping file was created...")
         mapping_file_path = get_mapper_from_sdk(options.dumper7_output_dir)
         if mapping_file_path is None:
             logger.error("DLL injection failed and mapping file was not created. Cannot continue.")

--- a/src/mapper/simple_injector.py
+++ b/src/mapper/simple_injector.py
@@ -188,7 +188,7 @@ class SimpleDLLInjector:
                 return True
                 
         except Exception as e:
-            logger.error(f"Exception during injection: {e}")
+            logger.info(f"Exception during injection: {e}")
             return False
         finally:
             ctypes.windll.kernel32.CloseHandle(h_process)

--- a/src/run.py
+++ b/src/run.py
@@ -320,7 +320,7 @@ def main(args: Namespace, log_file: str) -> bool:
             # If skipped mapper creation, use the expected output path
             mapper_file_path = options.output_mapper_file
             if not os.path.exists(mapper_file_path):
-                logger.error(f"Mapper file not found at {mapper_file_path}. Cannot skip mapper creation.")
+                logger.error(f"Mapper file not found at {mapper_file_path}. Cannot skip mapper creation for BatchExport.")
                 return False
             if not run_batch_export(options, mapper_file_path):
                 logger.error("BatchExport failed.")

--- a/src/run.py
+++ b/src/run.py
@@ -104,7 +104,7 @@ def run_steam_download_update(options: Options) -> bool:
             steam_password=options.steam_password,
             force=options.force_steam_download,
         )
-        manifest_id = None if options.manifest_id == "" else options.manifest_id
+        manifest_id = options.manifest_id
         result = downloader.run(manifest_id=manifest_id)
 
         end_time = time.time()

--- a/src/steam/run_depot_downloader.py
+++ b/src/steam/run_depot_downloader.py
@@ -1,10 +1,8 @@
 import os
 import shutil
 from loguru import logger
-from optionsconfig import init_options
 from utils import run_process
 from typing import Optional
-from pathlib import Path
 
 APP_ID = '1491000'  # war robots: frontier's app_id
 DEPOT_ID = '1491005'  # the big depot
@@ -27,9 +25,9 @@ class DepotDownloader:
         self.manifest_path = os.path.join(self.wrf_dir, 'manifest.txt')
         self.force = force
 
-    def run(self, manifest_id: Optional[str | None]) -> None:
+    def run(self, manifest_id: str) -> None:
         # no input manifest id downloads the latest version
-        if manifest_id is None:
+        if manifest_id == "latest":
             manifest_id = self._get_latest_manifest_id()
             logger.debug(f"DepotDownloader retrieved latest manifest id of: {manifest_id}")
 

--- a/tests/test_steam/test_depot_downloader.py
+++ b/tests/test_steam/test_depot_downloader.py
@@ -305,7 +305,7 @@ class TestDepotDownloader(unittest.TestCase):
                 with patch.object(depot, '_download') as mock_download:
                     with patch.object(depot, '_write_downloaded_manifest_id') as mock_write:
                         with patch.object(src_run_depot_downloader, 'logger') as mock_logger:
-                            depot.run(None)
+                            depot.run('latest')
                             
                             # Verify latest manifest was retrieved
                             mock_logger.debug.assert_called_with(f"DepotDownloader retrieved latest manifest id of: {latest_manifest_id}")


### PR DESCRIPTION
* `` (blank) manifest id functionality is now instead mimicked with passing `latest` manifest id
* Updated old references in `STANDARDS.md`
* Corrected `OUTPUT_MAPPER_FILE` to now depend on `SHOULD_BATCH_EXPORT`
* Removed/updated some old documentation
* Errors/warnings regarding injection are now infos, unless the final check for mapper file's is that it does not exist, in which case it throws an error. This is to make it easier to check if any single ERROR/WARNING appears in the log.